### PR TITLE
Update example tool parameter type from :text to :string

### DIFF
--- a/src/modex/mcp/core.clj
+++ b/src/modex/mcp/core.clj
@@ -11,7 +11,7 @@
   (tools/tools
     (greet
       "Greets the user. Takes name"
-      [^{:type :text :doc "A person's name."} name]
+      [^{:type :string :doc "A person's name."} name]
       (str "Hello from Modex, " name "!"))
 
     (inc


### PR DESCRIPTION
Claude Desktop crashes for type: "text" tool parameter. Use type: "string" instead, despite "text" return content type. Underspecified in spec. Still need to update tests.